### PR TITLE
chore(service): member  모듈 cicd 추가

### DIFF
--- a/.github/workflows/e-commerce-service_actions.yaml
+++ b/.github/workflows/e-commerce-service_actions.yaml
@@ -23,6 +23,7 @@ jobs:
       product: ${{ steps.filter.outputs.product }}
       review: ${{ steps.filter.outputs.review }}
       search: ${{ steps.filter.outputs.search }}
+      member: ${{ steps.filter.outputs.member }}
       # ✅ 추가: 변경된 서비스만의 JSON 배열
       changed-services: ${{ steps.generate-matrix.outputs.changed-services }}
     steps:
@@ -43,6 +44,8 @@ jobs:
               - 'service/review/**'
             search:
               - 'service/search/**'
+            member: 
+              - 'service/member/**'
           list-files: shell
       - name: Debug Outputs
         run: |
@@ -51,6 +54,7 @@ jobs:
           echo "Product Changed: ${{ steps.filter.outputs.product }}"
           echo "Review Changed: ${{ steps.filter.outputs.review }}"
           echo "Search Changed: ${{ steps.filter.outputs.search }}"
+          echo "Member Changed: ${{ steps.filter.outputs.member }}"
 
       # ✅ 새로 추가: 변경된 서비스만 추출
       - name: Generate changed services matrix
@@ -84,6 +88,10 @@ jobs:
             if [[ "${{ steps.filter.outputs.search }}" == "true" ]]; then
               changed_services=$(echo $changed_services | jq '. + ["search"]')
               echo "✅ search 배포 대상"
+            fi
+            if [[ "${{ steps.filter.outputs.member }}" == "true" ]]; then
+              changed_services=$(echo $changed_services | jq '. + ["member"]')
+              echo "✅ member 배포 대상"
             fi
           fi
           

--- a/service/member/Dockerfile
+++ b/service/member/Dockerfile
@@ -1,0 +1,12 @@
+# service/review/Dockerfile
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+COPY service/member/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENV JAVA_OPTS="-Xmx512m -Xms256m -XX:+UseG1GC"
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
-member 모듈 cicd 추가

todo
- 추후 fargate 형태로 배포하려면 ecs 클러스터에서 모듈별 task definition과 service를 생성 해놓아야 함.
- 클러스터 네트워크 설정 필요, 게이트 웨이만 로드밸런서를 통해 외부 연결

## 📋 작업 내용
<!-- 무엇을 변경했는지 간단히 설명 -->

## 🔗 관련 이슈
Closes #123

## 📸 스크린샷
<!-- UI 변경사항이 있다면 스크린샷 첨부 -->

## ✅ 체크리스트
- [ ] 테스트 코드 작성
- [ ] 모든 테스트 통과
- [ ] 코드 리뷰 요청
- [ ] 문서 업데이트 (필요시)